### PR TITLE
fix: upgrade dnt to fix npm package

### DIFF
--- a/build_npm.ts
+++ b/build_npm.ts
@@ -1,4 +1,4 @@
-import { build } from "https://deno.land/x/dnt@0.3.1/mod.ts";
+import { build } from "https://deno.land/x/dnt@0.4.0/mod.ts";
 import { copy } from "https://deno.land/std@0.113.0/fs/mod.ts";
 
 await Deno.remove("npm", { recursive: true }).catch((_) => {});
@@ -7,7 +7,11 @@ await copy("testdata", "npm/umd/testdata", { overwrite: true });
 await copy("README.md", "npm/README.md", { overwrite: true });
 
 await build({
-  entryPoints: ["./main.ts"],
+  entryPoints: ["./lib.ts", {
+    kind: "bin",
+    name: "license_checker",
+    path: "./main.ts",
+  }],
   outDir: "./npm",
   typeCheck: false,
   declaration: true,
@@ -18,9 +22,6 @@ await build({
     version: "3.1.4",
     description: "📄 CLI tool for checking license headers in files",
     license: "MIT",
-    bin: {
-      license_checker: "./umd/main.js",
-    },
     repository: {
       type: "git",
       url: "git+https://github.com/kt3k/deno_license_checker.git",
@@ -30,3 +31,9 @@ await build({
     },
   },
 });
+
+await Deno.writeTextFile(
+  "npm/.npmignore",
+  "esm/testdata/\numd/testdata/\n",
+  { append: true }
+);

--- a/build_npm.ts
+++ b/build_npm.ts
@@ -1,4 +1,4 @@
-import { build } from "https://deno.land/x/dnt@0.4.0/mod.ts";
+import { build } from "https://deno.land/x/dnt@0.4.1/mod.ts";
 import { copy } from "https://deno.land/std@0.113.0/fs/mod.ts";
 
 await Deno.remove("npm", { recursive: true }).catch((_) => {});
@@ -13,7 +13,7 @@ await build({
     path: "./main.ts",
   }],
   outDir: "./npm",
-  typeCheck: false,
+  typeCheck: true,
   declaration: true,
   test: true,
   package: {


### PR DESCRIPTION
```bash
> npm publish --dry-run
npm notice 
npm notice 📦  @kt3k/license-checker@3.1.4
npm notice === Tarball Contents ===
npm notice 4.5kB  README.md
npm notice 492B   esm/deps.js
npm notice 392B   esm/deps/deno_land/std_0.102.0/_util/assert.js
npm notice 625B   esm/deps/deno_land/std_0.102.0/_util/os.js
npm notice 4.9kB  esm/deps/deno_land/std_0.102.0/bytes/mod.js
npm notice 8.5kB  esm/deps/deno_land/std_0.102.0/flags/mod.js
npm notice 10.6kB esm/deps/deno_land/std_0.102.0/fmt/colors.js
npm notice 906B   esm/deps/deno_land/std_0.102.0/fs/_util.js
npm notice 8.5kB  esm/deps/deno_land/std_0.102.0/fs/copy.js
npm notice 2.0kB  esm/deps/deno_land/std_0.102.0/fs/empty_dir.js
npm notice 1.5kB  esm/deps/deno_land/std_0.102.0/fs/ensure_dir.js
npm notice 2.1kB  esm/deps/deno_land/std_0.102.0/fs/ensure_file.js
npm notice 1.7kB  esm/deps/deno_land/std_0.102.0/fs/ensure_link.js
npm notice 2.2kB  esm/deps/deno_land/std_0.102.0/fs/ensure_symlink.js
npm notice 682B   esm/deps/deno_land/std_0.102.0/fs/eol.js
npm notice 808B   esm/deps/deno_land/std_0.102.0/fs/exists.js
npm notice 7.4kB  esm/deps/deno_land/std_0.102.0/fs/expand_glob.js
npm notice 415B   esm/deps/deno_land/std_0.102.0/fs/mod.js
npm notice 1.4kB  esm/deps/deno_land/std_0.102.0/fs/move.js
npm notice 5.0kB  esm/deps/deno_land/std_0.102.0/fs/walk.js
npm notice 10.9kB esm/deps/deno_land/std_0.102.0/io/buffer.js
npm notice 9.0kB  esm/deps/deno_land/std_0.102.0/io/util.js
npm notice 1.9kB  esm/deps/deno_land/std_0.102.0/path/_constants.js
npm notice 124B   esm/deps/deno_land/std_0.102.0/path/_interface.js
npm notice 4.0kB  esm/deps/deno_land/std_0.102.0/path/_util.js
npm notice 1.2kB  esm/deps/deno_land/std_0.102.0/path/common.js
npm notice 13.9kB esm/deps/deno_land/std_0.102.0/path/glob.js
npm notice 691B   esm/deps/deno_land/std_0.102.0/path/mod.js
npm notice 16.2kB esm/deps/deno_land/std_0.102.0/path/posix.js
npm notice 257B   esm/deps/deno_land/std_0.102.0/path/separator.js
npm notice 35.1kB esm/deps/deno_land/std_0.102.0/path/win32.js
npm notice 9.0kB  esm/deps/deno_land/std_0.102.0/testing/_diff.js
npm notice 16.1kB esm/deps/deno_land/std_0.102.0/testing/asserts.js
npm notice 2.4kB  esm/lib.js
npm notice 2.1kB  esm/main.js
npm notice 23B    esm/package.json
npm notice 996B   esm/util.js
npm notice 820B   package.json
npm notice 422B   types/deps.d.ts
npm notice 222B   types/deps/deno_land/std_0.102.0/_util/assert.d.ts
npm notice 75B    types/deps/deno_land/std_0.102.0/_util/os.d.ts
npm notice 2.3kB  types/deps/deno_land/std_0.102.0/bytes/mod.d.ts
npm notice 2.2kB  types/deps/deno_land/std_0.102.0/flags/mod.d.ts
npm notice 7.5kB  types/deps/deno_land/std_0.102.0/fmt/colors.d.ts
npm notice 584B   types/deps/deno_land/std_0.102.0/fs/_util.d.ts
npm notice 1.5kB  types/deps/deno_land/std_0.102.0/fs/copy.d.ts
npm notice 629B   types/deps/deno_land/std_0.102.0/fs/empty_dir.d.ts
npm notice 479B   types/deps/deno_land/std_0.102.0/fs/ensure_dir.d.ts
npm notice 672B   types/deps/deno_land/std_0.102.0/fs/ensure_file.d.ts
npm notice 601B   types/deps/deno_land/std_0.102.0/fs/ensure_link.d.ts
npm notice 519B   types/deps/deno_land/std_0.102.0/fs/ensure_symlink.d.ts
npm notice 348B   types/deps/deno_land/std_0.102.0/fs/eol.d.ts
npm notice 303B   types/deps/deno_land/std_0.102.0/fs/exists.d.ts
npm notice 1.1kB  types/deps/deno_land/std_0.102.0/fs/expand_glob.d.ts
npm notice 340B   types/deps/deno_land/std_0.102.0/fs/mod.d.ts
npm notice 339B   types/deps/deno_land/std_0.102.0/fs/move.d.ts
npm notice 1.6kB  types/deps/deno_land/std_0.102.0/fs/walk.d.ts
npm notice 4.0kB  types/deps/deno_land/std_0.102.0/io/buffer.d.ts
npm notice 988B   types/deps/deno_land/std_0.102.0/io/readers.d.ts
npm notice 6.7kB  types/deps/deno_land/std_0.102.0/io/util.d.ts
npm notice 1.7kB  types/deps/deno_land/std_0.102.0/path/_constants.d.ts
npm notice 661B   types/deps/deno_land/std_0.102.0/path/_interface.d.ts
npm notice 625B   types/deps/deno_land/std_0.102.0/path/_util.d.ts
npm notice 433B   types/deps/deno_land/std_0.102.0/path/common.d.ts
npm notice 4.1kB  types/deps/deno_land/std_0.102.0/path/glob.d.ts
npm notice 1.1kB  types/deps/deno_land/std_0.102.0/path/mod.d.ts
npm notice 2.4kB  types/deps/deno_land/std_0.102.0/path/posix.d.ts
npm notice 76B    types/deps/deno_land/std_0.102.0/path/separator.d.ts
npm notice 2.7kB  types/deps/deno_land/std_0.102.0/path/win32.d.ts
npm notice 671B   types/deps/deno_land/std_0.102.0/testing/_diff.d.ts
npm notice 4.8kB  types/deps/deno_land/std_0.102.0/testing/asserts.d.ts
npm notice 76B    types/deps/deno_land/x/which_runtime_0.1.0/mod.d.ts
npm notice 227B   types/dev_deps.d.ts
npm notice 343B   types/lib.d.ts
npm notice 31B    types/main.d.ts
npm notice 11B    types/test.d.ts
npm notice 321B   types/util.d.ts
npm notice 2.4kB  umd/deps.js
npm notice 986B   umd/deps/deno_land/std_0.102.0/_util/assert.js
npm notice 1.2kB  umd/deps/deno_land/std_0.102.0/_util/os.js
npm notice 6.4kB  umd/deps/deno_land/std_0.102.0/bytes/mod.js
npm notice 10.0kB umd/deps/deno_land/std_0.102.0/flags/mod.js
npm notice 15.0kB umd/deps/deno_land/std_0.102.0/fmt/colors.js
npm notice 1.7kB  umd/deps/deno_land/std_0.102.0/fs/_util.js
npm notice 10.5kB umd/deps/deno_land/std_0.102.0/fs/copy.js
npm notice 2.9kB  umd/deps/deno_land/std_0.102.0/fs/empty_dir.js
npm notice 2.4kB  umd/deps/deno_land/std_0.102.0/fs/ensure_dir.js
npm notice 3.1kB  umd/deps/deno_land/std_0.102.0/fs/ensure_file.js
npm notice 2.6kB  umd/deps/deno_land/std_0.102.0/fs/ensure_link.js
npm notice 3.3kB  umd/deps/deno_land/std_0.102.0/fs/ensure_symlink.js
npm notice 1.3kB  umd/deps/deno_land/std_0.102.0/fs/eol.js
npm notice 1.5kB  umd/deps/deno_land/std_0.102.0/fs/exists.js
npm notice 9.4kB  umd/deps/deno_land/std_0.102.0/fs/expand_glob.js
npm notice 1.5kB  umd/deps/deno_land/std_0.102.0/fs/mod.js
npm notice 2.3kB  umd/deps/deno_land/std_0.102.0/fs/move.js
npm notice 6.6kB  umd/deps/deno_land/std_0.102.0/fs/walk.js
npm notice 12.9kB umd/deps/deno_land/std_0.102.0/io/buffer.js
npm notice 11.3kB umd/deps/deno_land/std_0.102.0/io/util.js
npm notice 3.4kB  umd/deps/deno_land/std_0.102.0/path/_constants.js
npm notice 527B   umd/deps/deno_land/std_0.102.0/path/_interface.js
npm notice 5.4kB  umd/deps/deno_land/std_0.102.0/path/_util.js
npm notice 1.9kB  umd/deps/deno_land/std_0.102.0/path/common.js
npm notice 16.1kB umd/deps/deno_land/std_0.102.0/path/glob.js
npm notice 2.4kB  umd/deps/deno_land/std_0.102.0/path/mod.js
npm notice 19.8kB umd/deps/deno_land/std_0.102.0/path/posix.js
npm notice 754B   umd/deps/deno_land/std_0.102.0/path/separator.js
npm notice 41.4kB umd/deps/deno_land/std_0.102.0/path/win32.js
npm notice 10.5kB umd/deps/deno_land/std_0.102.0/testing/_diff.js
npm notice 20.1kB umd/deps/deno_land/std_0.102.0/testing/asserts.js
npm notice 3.3kB  umd/lib.js
npm notice 3.0kB  umd/main.js
npm notice 25B    umd/package.json
npm notice 1.9kB  umd/util.js
npm notice === Tarball Details ===
npm notice name:          @kt3k/license-checker
npm notice version:       3.1.4
npm notice filename:      @kt3k/license-checker-3.1.4.tgz
npm notice package size:  78.2 kB
npm notice unpacked size: 482.8 kB
npm notice shasum:        316246afeb772142a3b2dd66be925e56369e9925
npm notice integrity:     sha512-LGieR5w5YEKeB[...]qk0JorI8qxFkA==
npm notice total files:   113
npm notice
+ @kt3k/license-checker@3.1.4
```